### PR TITLE
Making run_all.py to stop on first failure

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import subprocess
 import operator
 import random
 import time
@@ -166,7 +167,8 @@ def write_chart_markdown_and_html(
     with open(f"{chart_script_name}.md", "w") as md:
         with open(chart_script, "r") as f:
             chart_model = chart_model.replace("{code}", f.read())
-        os.system(f"python3 {chart_script}")
+        subprocess.check_call(["python3", chart_script], stdout=subprocess.PIPE)
+
         chart_model = chart_model.replace(
             "{html}", f"{folder}/{chart_script_name}.html"
         )


### PR DESCRIPTION
It is useful to detect errors early and fail. Especially when there are missing dependencies,
and the user wants to abort the processing on the first, but hitting Ctrl-C or Ctrl-D just makes
the error messages worse, and the whole process continues forward.

![Screenshot from 2020-10-14 21-20-06](https://user-images.githubusercontent.com/5195944/96029285-1f9f0b00-0e63-11eb-95eb-1e6c76daac16.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyecharts/pyecharts-gallery/37)
<!-- Reviewable:end -->

