### PR TITLE
fixing file removal not to swipe .git metadata

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 # 清理的命令
 ClearCmd: str = (
     'find ./ -mindepth 2 -type f ! -name "*.py" ! -name "*.json" ! '
-    '-path ".//.idea/*" ! -path ".//.mypy_cache/*" ! -path ".//.git/*" '
+    '-path "./.idea/*" ! -path "./.mypy_cache/*" ! -path "./.git/*" '
     "| xargs rm -f"
 )
 
@@ -146,6 +146,7 @@ def save_md5_to_json(md5_json: dict):
 def clear_all():
     print("正在清理...")
     try:
+        print(ClearCmd)
         os.system(ClearCmd)
         time.sleep(3)
         print("清理成功!")


### PR DESCRIPTION
In my Linux system, that find expression couldn't match with
.git directory, and caused removal of .git metadata. This is
harmful for open source contributors especially.

Now also printing the command to make this behavior more
explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyecharts/pyecharts-gallery/38)
<!-- Reviewable:end -->
