### PR TITLE
replace echarts.baidu.com to echarts.apache.org

### DIFF
--- a/BMap/hiking_trail_in_hangzhou.md
+++ b/BMap/hiking_trail_in_hangzhou.md
@@ -19,7 +19,7 @@ async def get_json_data(url: str) -> dict:
 # 获取官方的数据
 data = asyncio.run(
     get_json_data(
-        url="https://echarts.baidu.com/examples/data/asset/data/hangzhou-tracks.json"
+        url="https://echarts.apache.org/examples/data/asset/data/hangzhou-tracks.json"
     )
 )
 

--- a/Bar3D/bar3d_punch_card.md
+++ b/Bar3D/bar3d_punch_card.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Bar3D
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=bar3d-punch-card&gl=1
+参考地址: https://echarts.apache.org/examples/editor.html?c=bar3d-punch-card&gl=1
 
 目前无法实现的功能:
 

--- a/Candlestick/professional_kline_brush.md
+++ b/Candlestick/professional_kline_brush.md
@@ -11,7 +11,7 @@ from pyecharts.charts import Kline, Line, Bar, Grid
 
 def get_data():
     response = requests.get(
-        url="https://echarts.baidu.com/examples/data/asset/data/stock-DJI.json"
+        url="https://echarts.apache.org/examples/data/asset/data/stock-DJI.json"
     )
     json_response = response.json()
     # 解析数据

--- a/Funnel/funnel_chart.md
+++ b/Funnel/funnel_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Funnel
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=funnel
+参考地址: https://echarts.apache.org/examples/editor.html?c=funnel
 
 目前无法实现的功能:
 

--- a/Gauge/gauge.md
+++ b/Gauge/gauge.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Gauge
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=gauge
+参考地址: https://echarts.apache.org/examples/editor.html?c=gauge
 
 目前无法实现的功能:
 

--- a/Graph/npm_dependencies.md
+++ b/Graph/npm_dependencies.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Graph
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=graph-npm
+参考地址: https://echarts.apache.org/examples/editor.html?c=graph-npm
 
 目前无法实现的功能:
 
@@ -27,7 +27,7 @@ async def get_json_data(url: str) -> dict:
 # 获取官方的数据
 data = asyncio.run(
     get_json_data(
-        url="https://echarts.baidu.com/examples/data/asset/data/npmdepgraph.min10.json"
+        url="https://echarts.apache.org/examples/data/asset/data/npmdepgraph.min10.json"
     )
 )
 

--- a/Heatmap/heatmap_on_cartesian.md
+++ b/Heatmap/heatmap_on_cartesian.md
@@ -7,7 +7,7 @@ from pyecharts.charts import HeatMap
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=heatmap-cartesian
+参考地址: https://echarts.apache.org/examples/editor.html?c=heatmap-cartesian
 
 目前无法实现的功能:
 

--- a/Line/basic_area_chart.md
+++ b/Line/basic_area_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=area-basic
+参考地址: https://echarts.apache.org/examples/editor.html?c=area-basic
 
 目前无法实现的功能:
 

--- a/Line/basic_line_chart.md
+++ b/Line/basic_line_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=line-simple
+参考地址: https://echarts.apache.org/examples/editor.html?c=line-simple
 
 目前无法实现的功能:
 

--- a/Line/beijing_aqi.md
+++ b/Line/beijing_aqi.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=line-aqi
+参考地址: https://echarts.apache.org/examples/editor.html?c=line-aqi
 
 目前无法实现的功能:
 

--- a/Line/multiple_x_axes.md
+++ b/Line/multiple_x_axes.md
@@ -10,7 +10,7 @@ from pyecharts.commons.utils import JsCode
 
 """
 Gallery 使用 pyecharts 1.0.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=multiple-x-axis
+参考地址: https://echarts.apache.org/examples/editor.html?c=multiple-x-axis
 
 目前无法实现的功能:
 

--- a/Line/rainfall.md
+++ b/Line/rainfall.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址:  https://echarts.baidu.com/examples/editor.html?c=area-rainfall
+参考地址:  https://echarts.apache.org/examples/editor.html?c=area-rainfall
 
 目前无法实现的功能:
 

--- a/Line/smoothed_line_chart.md
+++ b/Line/smoothed_line_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=line-smooth
+参考地址: https://echarts.apache.org/examples/editor.html?c=line-smooth
 
 目前无法实现的功能:
 

--- a/Line/stacked_area_chart.md
+++ b/Line/stacked_area_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=area-stack
+参考地址: https://echarts.apache.org/examples/editor.html?c=area-stack
 
 目前无法实现的功能:
 

--- a/Line/stacked_line_chart.md
+++ b/Line/stacked_line_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Line
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=line-stack
+参考地址: https://echarts.apache.org/examples/editor.html?c=line-stack
 
 目前无法实现的功能:
 

--- a/Map/population_density_of_HongKong.md
+++ b/Map/population_density_of_HongKong.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Map
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=map-HK
+参考地址: https://echarts.apache.org/examples/editor.html?c=map-HK
 """
 
 WIKI_LINK = (
@@ -27,7 +27,7 @@ async def get_json_data(url: str) -> dict:
 
 # 下载香港地图
 data = asyncio.run(
-    get_json_data(url="https://echarts.baidu.com/examples/data/asset/geo/HK.json")
+    get_json_data(url="https://echarts.apache.org/examples/data/asset/geo/HK.json")
 )
 
 MAP_DATA = [

--- a/Map/population_density_of_HongKong_v2.md
+++ b/Map/population_density_of_HongKong_v2.md
@@ -10,7 +10,7 @@ from pyecharts.datasets import register_url
 
 """
 Gallery 使用 pyecharts 1.1.0 和 echarts-china-cities-js
-参考地址: https://echarts.baidu.com/examples/editor.html?c=map-HK
+参考地址: https://echarts.apache.org/examples/editor.html?c=map-HK
 """
 ssl._create_default_https_context = ssl._create_unverified_context
 # 与 pyecharts 注册，当画香港地图的时候，用 echarts-china-cities-js

--- a/Parallel/basic_parallel.md
+++ b/Parallel/basic_parallel.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Parallel
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=parallel-simple
+参考地址: https://echarts.apache.org/examples/editor.html?c=parallel-simple
 
 目前无法实现的功能:
 

--- a/Pie/customized_pie.md
+++ b/Pie/customized_pie.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Pie
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=pie-doughnut
+参考地址: https://echarts.apache.org/examples/editor.html?c=pie-doughnut
 
 目前无法实现的功能:
 

--- a/Pie/doughnut_chart.md
+++ b/Pie/doughnut_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Pie
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=pie-doughnut
+参考地址: https://echarts.apache.org/examples/editor.html?c=pie-doughnut
 
 目前无法实现的功能:
 

--- a/Pie/nested_pies.md
+++ b/Pie/nested_pies.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Pie
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=pie-nest
+参考地址: https://echarts.apache.org/examples/editor.html?c=pie-nest
 
 目前无法实现的功能:
 

--- a/Radar/basic_radar_chart.md
+++ b/Radar/basic_radar_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Radar
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=radar
+参考地址: https://echarts.apache.org/examples/editor.html?c=radar
 
 目前无法实现的功能:
 

--- a/Sankey/sankey_diagram.md
+++ b/Sankey/sankey_diagram.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Sankey
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=sankey-energy
+参考地址: https://echarts.apache.org/examples/editor.html?c=sankey-energy
 
 目前无法实现的功能:
 
@@ -26,7 +26,7 @@ async def get_json_data(url: str) -> dict:
 
 # 获取官方的数据
 data = asyncio.run(
-    get_json_data(url="https://echarts.baidu.com/examples/data/asset/data/energy.json")
+    get_json_data(url="https://echarts.apache.org/examples/data/asset/data/energy.json")
 )
 
 (

--- a/Scatter/basic_scatter_chart.md
+++ b/Scatter/basic_scatter_chart.md
@@ -7,7 +7,7 @@ from pyecharts.charts import Scatter
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=scatter-simple
+参考地址: https://echarts.apache.org/examples/editor.html?c=scatter-simple
 
 目前无法实现的功能:
 

--- a/Scatter3D/scatter3d.md
+++ b/Scatter3D/scatter3d.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Scatter3D
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=scatter3d&gl=1&theme=dark
+参考地址: https://echarts.apache.org/examples/editor.html?c=scatter3d&gl=1&theme=dark
 
 目前无法实现的功能:
 
@@ -27,7 +27,7 @@ async def get_json_data(url: str) -> dict:
 # 获取官方的数据
 data = asyncio.run(
     get_json_data(
-        url="https://echarts.baidu.com/examples/data/asset/data/nutrients.json"
+        url="https://echarts.apache.org/examples/data/asset/data/nutrients.json"
     )
 )
 

--- a/Surface3D/surface_wave.md
+++ b/Surface3D/surface_wave.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Surface3D
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=surface-wave&gl=1
+参考地址: https://echarts.apache.org/examples/editor.html?c=surface-wave&gl=1
 
 目前无法实现的功能:
 

--- a/ThemeRiver/theme_river.md
+++ b/ThemeRiver/theme_river.md
@@ -7,7 +7,7 @@ from pyecharts.charts import ThemeRiver
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=themeRiver-basic
+参考地址: https://echarts.apache.org/examples/editor.html?c=themeRiver-basic
 
 目前无法实现的功能:
 

--- a/Tree/radial_tree.md
+++ b/Tree/radial_tree.md
@@ -10,7 +10,7 @@ from pyecharts.charts import Tree
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=tree-radial
+参考地址: https://echarts.apache.org/examples/editor.html?c=tree-radial
 
 目前无法实现的功能:
 
@@ -26,7 +26,7 @@ async def get_json_data(url: str) -> dict:
 
 # 获取官方的数据
 data = asyncio.run(
-    get_json_data(url="https://echarts.baidu.com/examples/data/asset/data/flare.json")
+    get_json_data(url="https://echarts.apache.org/examples/data/asset/data/flare.json")
 )
 
 (

--- a/Treemap/echarts_option_query.md
+++ b/Treemap/echarts_option_query.md
@@ -11,7 +11,7 @@ from pyecharts.charts import TreeMap
 
 """
 Gallery 使用 pyecharts 1.1.0
-参考地址: https://echarts.baidu.com/examples/editor.html?c=treemap-drill-down
+参考地址: https://echarts.apache.org/examples/editor.html?c=treemap-drill-down
 
 目前无法实现的功能:
 
@@ -28,7 +28,7 @@ async def get_json_data(url: str) -> dict:
 # 获取官方的数据
 data = asyncio.run(
     get_json_data(
-        url="https://echarts.baidu.com/examples/data/asset/data/"
+        url="https://echarts.apache.org/examples/data/asset/data/"
         "ec-option-doc-statistics-201604.json"
     )
 )


### PR DESCRIPTION
echarts.baidu.com域名失效, 点开后会显示如下内容:

![](https://cdn.jsdelivr.net/gh/fnsflmzqdydk/myPicbed/2021/03/15/020-c3396a.jpg)

替换为echarts.apache.org能正常使用